### PR TITLE
Add local storage for pin that may not be in cache

### DIFF
--- a/src/components/principal/Home.js
+++ b/src/components/principal/Home.js
@@ -186,6 +186,19 @@ class Home extends Component {
 
     sendSurvey = async () => { //Send Survey GOOD CHOICE
         this.showAlert();
+        try {
+            let currentPin = {
+                household_id: this.state.householdID,
+                latitude: this.state.userLatitude,
+                longitude: this.state.userLongitude
+            }
+            await AsyncStorage.setItem(
+                "localpin",
+                JSON.stringify(currentPin)
+            )
+        } catch (error) {
+            console.warn("Não conseguiu guardar pino local")
+        }
         return fetch(`${API_URL}/users/${this.state.userID}/surveys`, {
             method: 'POST',
             headers: {

--- a/src/components/principal/Maps.js
+++ b/src/components/principal/Maps.js
@@ -38,7 +38,8 @@ class Maps extends Component {
         this.getSurvey();
     }
 
-    getSurvey = () => {//Get Survey
+    getSurvey = async () => {//Get Survey
+        let localpin = JSON.parse(await AsyncStorage.getItem('localpin'))
         return fetch(`${API_URL}/surveys/week`, {
             headers: {
                 Accept: 'application/vnd.api+json',
@@ -47,9 +48,15 @@ class Maps extends Component {
         })
             .then((response) => response.json())
             .then((responseJson) => {
-                this.setState({
-                    dataSource: responseJson.surveys
-                })
+                if (localpin !== null) {
+                    this.setState({
+                        dataSource: [...responseJson.surveys, localpin]
+                    })
+                } else {
+                    this.setState({
+                        dataSource: responseJson.surveys
+                    })
+                }
                 this.getSurveyPerState()
             })
     }

--- a/src/components/principal/badReport.js
+++ b/src/components/principal/badReport.js
@@ -166,6 +166,20 @@ class BadReport extends Component {
 
     sendSurvey = async () => {
         this.showAlert();
+        try {
+            let currentPin = {
+                household_id: this.state.householdID,
+                latitude: this.state.userLatitude,
+                longitude: this.state.userLongitude,
+                symptom: this.state.symptoms
+            }
+            await AsyncStorage.setItem(
+                "localpin",
+                JSON.stringify(currentPin)
+            )
+        } catch (error) {
+            console.warn("Não conseguiu guardar pino local")
+        }
         return fetch(`${API_URL}/users/${this.state.userID}/surveys`, {
             method: 'POST',
             headers: {


### PR DESCRIPTION
**Descrição**<br>

Em decorrência da implementação do cache na API, quando um usuário cria um pino novo ele talvez não veja esse pino no mapa poucos instantes depois de criar-lo. 

Esse PR, para a issue #37, faz com que o último pino da última survey feita pelo usuário seja guardado localmente para ser visto no mapa, assim gerando uma experiência melhor com o app. 

**Checklist**
- [x] Código compila corretamente (Se aplicável);
- [x] Mudanças realizadas foram testadas e passaram no testes (Se aplicável);
- [x] Feito por conta própria (Se aplicável).
