### PR TITLE
Removing deploy stage on pull request

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,5 +51,5 @@ jobs:
         on:
           repo: proepidesenvolvimento/guardioes-app
           all_branches: true
-          condition: ($TRAVIS_BRANCH =~ ^(development)) AND ($TRAVIS_PULL_REQUEST = false)$
+          condition: $TRAVIS_BRANCH =~ ^(development) AND $TRAVIS_PULL_REQUEST=false
         skip_cleanup: 'true'

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,5 +51,5 @@ jobs:
         on:
           repo: proepidesenvolvimento/guardioes-app
           all_branches: true
-          condition: $TRAVIS_BRANCH =~ ^(development)$
+          condition: ($TRAVIS_BRANCH =~ ^(development)) AND ($TRAVIS_PULL_REQUEST = false)$
         skip_cleanup: 'true'


### PR DESCRIPTION
**Descrição**<br>

Quando um usuário externo ao repositório faz um Pull Request o pipeline falha. O motivo disso é que usuários externos não possuem acesso às chaves do repositório original, por questões de segurança, e como a etapa de deploy precisa das chaves para gerar o aplicativo em APK, ele falha.

Nesse Pull Request a etapa de deploy não é executada quando o pipeline foi inicializado por um PR. 

Essa solução foi baseada em [Pull Requests and Security Restrictions - Travis](https://docs.travis-ci.com/user/pull-requests/#pull-requests-and-security-restrictions)

**Checklist**
- [x] Código compila corretamente (Se aplicável);
- [ ] Mudanças realizadas foram testadas e passaram no testes (Se aplicável);
- [ ] Documentos gerados/atualizados (Se aplicável);
- [ ] Feito por conta própria (Se aplicável).
