### PR TITLE
Fix get cities of Pernambuco

### DIFF
--- a/src/utils/brasil.js
+++ b/src/utils/brasil.js
@@ -3330,7 +3330,7 @@ export function getCity(city) {
                ]
                break;
 
-          case "PERNANBUCO":
+          case "PERNAMBUCO":
                CITIES = [
                     { key: "ABREU E LIMA", label: "ABREU E LIMA" },
                     { key: "AFOGADOS DA INGAZEIRA", label: "AFOGADOS DA INGAZEIRA" },


### PR DESCRIPTION
**Descrição**<br>
Corrige o bug da função getCity() quando o estado selecionado é o de Pernambuco.<br>

**Checklist**
- [x] Código compila corretamente (Se aplicável);
- [x] Mudanças realizadas foram testadas e passaram no testes (Se aplicável);
- [ ] Documentos gerados/atualizados (Se aplicável);
- [ ] Feito por conta própria (Se aplicável).
