### PR TITLE
Fix Noticias buttons when Group twitter is null

### DIFF
--- a/src/screens/principal/Noticias/index.js
+++ b/src/screens/principal/Noticias/index.js
@@ -39,9 +39,13 @@ const Noticias = () => {
             if (response.status === 200) {
                 setGroupTwitter(response.body.twitter)
 
-                if (response.body.twitter) {
+                if (
+                    response.body.twitter &&
+                    response.body.twitter !== app.twitter
+                ) {
                     setTwitterOption(response.body.twitter)
                 } else {
+                    setGroupTwitter(null)
                     setTwitterOption(app.twitter)
                 }
             } else {


### PR DESCRIPTION
**Descrição**<br>
Corrige os botões da tela Noticias quando a Instituição que o usuário faz parte é nula.<br>

**Checklist**
- [x] Código compila corretamente (Se aplicável);
- [x] Mudanças realizadas foram testadas e passaram no testes (Se aplicável);
- [ ] Documentos gerados/atualizados (Se aplicável);
- [ ] Feito por conta própria (Se aplicável).
