### PR TITLE
BUG de embaralhamento do seletor de instituições.

### DIFF
--- a/src/components/Groups/InstitutionSelector.js
+++ b/src/components/Groups/InstitutionSelector.js
@@ -43,6 +43,11 @@ class InstitutionSelector extends Component {
         }
     }
 
+    componentWillUnmount(){
+        delete this.state
+        console.warn(this.state)
+    }
+
     // eslint-disable-next-line react/sort-comp
     isInputValid() {
         if (this.state.groupCheckbox === false) {
@@ -176,7 +181,7 @@ class InstitutionSelector extends Component {
                     const selectionIndexes = this.state.selectionIndexes.slice()
                     selectionIndexes.push({
                         label: translate('selector.label'),
-                        key: this.state.selectionIndexes.length,
+                        key: -1,
                     })
 
                     const groupList = this.state.groupList.slice()
@@ -267,7 +272,6 @@ class InstitutionSelector extends Component {
                                 selectionIndexes: [
                                     ...this.state.selectionIndexes.slice(0, index),
                                     option,
-                                    ...this.state.selectionIndexes.slice(index + 1),
                                 ],
                             })
 

--- a/src/components/Groups/InstitutionSelector.js
+++ b/src/components/Groups/InstitutionSelector.js
@@ -26,6 +26,7 @@ class InstitutionSelector extends Component {
             groupCheckbox: false,
             groupList: [],
             selectionIndexes: [],
+            selectorArray: [], 
             rootGroup: null,
             idCodeInputShow: false,
             userGroup: props.userGroup || null,
@@ -175,7 +176,7 @@ class InstitutionSelector extends Component {
                     const selectionIndexes = this.state.selectionIndexes.slice()
                     selectionIndexes.push({
                         label: translate('selector.label'),
-                        key: -1,
+                        key: this.state.selectionIndexes.length,
                     })
 
                     const groupList = this.state.groupList.slice()

--- a/src/components/Groups/InstitutionSelector.js
+++ b/src/components/Groups/InstitutionSelector.js
@@ -26,7 +26,6 @@ class InstitutionSelector extends Component {
             groupCheckbox: false,
             groupList: [],
             selectionIndexes: [],
-            selectorArray: [], 
             rootGroup: null,
             idCodeInputShow: false,
             userGroup: props.userGroup || null,
@@ -56,8 +55,8 @@ class InstitutionSelector extends Component {
             return false
         }
 
-        const doesTheSelectedGroupRequireID = this.state.selectedGroup
-            .group_manager.require_id !== null;
+        const doesTheSelectedGroupRequireID =
+            this.state.selectedGroup.group_manager.require_id !== null
 
         const isIdPresentIfNeeded = doesTheSelectedGroupRequireID
             ? this.state.userIdCode !== null && this.state.userIdCode.length > 0
@@ -66,7 +65,7 @@ class InstitutionSelector extends Component {
             this.setState({ currentError: translate('selector.codeError') })
         }
 
-        let isIdRightLength = true
+        const isIdRightLength = true
         /*
         if (doesTheSelectedGroupRequireID && isIdPresentIfNeeded) {
             isIdRightLength =
@@ -83,7 +82,7 @@ class InstitutionSelector extends Component {
         }
         */
 
-        let codeIsNumber = true
+        const codeIsNumber = true
         /*
         if (
             doesTheSelectedGroupRequireID &&
@@ -99,19 +98,11 @@ class InstitutionSelector extends Component {
         }
         */
 
-        if (
-            isIdPresentIfNeeded &&
-            isIdRightLength &&
-            codeIsNumber
-        ) {
+        if (isIdPresentIfNeeded && isIdRightLength && codeIsNumber) {
             this.setState({ currentError: '' })
         }
 
-        return (
-            isIdPresentIfNeeded &&
-            isIdRightLength &&
-            codeIsNumber
-        )
+        return isIdPresentIfNeeded && isIdRightLength && codeIsNumber
     }
 
     updateParent() {
@@ -142,23 +133,22 @@ class InstitutionSelector extends Component {
             })
     }
 
-	insertSortToGroupList(data){
-		let groupList = this.state.groupList.slice()
+    insertSortToGroupList(data) {
+        const groupList = this.state.groupList.slice()
 
-		groupList.push(data)
-		for (let i=parseInt(groupList.length)-1; i>0; i-=1){
-			if (groupList[i]['id'] < groupList[i-1]['id']){
-				let tmp = groupList[i]
-				groupList[i] = groupList[i-1]
-				groupList[i-1] = tmp
-			}
-			else {
-				break
-			}
-		}
+        groupList.push(data)
+        for (let i = parseInt(groupList.length, 10) - 1; i > 0; i -= 1) {
+            if (groupList[i].id < groupList[i - 1].id) {
+                const tmp = groupList[i]
+                groupList[i] = groupList[i - 1]
+                groupList[i - 1] = tmp
+            } else {
+                break
+            }
+        }
 
-		this.setState({ groupList })
-	}
+        this.setState({ groupList })
+    }
 
     async getGroup(id, setAlert = true) {
         if (setAlert) this.props.setAlert(true)
@@ -201,7 +191,10 @@ class InstitutionSelector extends Component {
                         key: -1,
                     })
 
-                    this.insertSortToGroupList({...response.body, id: parseInt(id)})
+                    this.insertSortToGroupList({
+                        ...response.body,
+                        id: parseInt(id, 10),
+                    })
                     this.setState({ selectionIndexes })
                 }
             })
@@ -273,10 +266,16 @@ class InstitutionSelector extends Component {
                         value={this.state.selectionIndexes[index].label}
                         onChange={(option) => {
                             this.setState({
-                                groupList: this.state.groupList.slice(0, index + 1),
+                                groupList: this.state.groupList.slice(
+                                    0,
+                                    index + 1
+                                ),
                             })
                             this.setState({
-                                selectionIndexes: this.state.selectionIndexes.slice(0, index + 1),
+                                selectionIndexes: this.state.selectionIndexes.slice(
+                                    0,
+                                    index + 1
+                                ),
                             })
                             this.setState({ idCodeInputShow: false })
 
@@ -284,7 +283,10 @@ class InstitutionSelector extends Component {
 
                             this.setState({
                                 selectionIndexes: [
-                                    ...this.state.selectionIndexes.slice(0, index),
+                                    ...this.state.selectionIndexes.slice(
+                                        0,
+                                        index
+                                    ),
                                     option,
                                 ],
                             })

--- a/src/components/Groups/InstitutionSelector.js
+++ b/src/components/Groups/InstitutionSelector.js
@@ -55,11 +55,6 @@ class InstitutionSelector extends Component {
             return false
         }
 
-        const isThereSelectedGroup = this.state.selectedGroup !== null
-        if (!isThereSelectedGroup) {
-            this.setState({ currentError: translate('selector.groupError') })
-        }
-
         const doesTheSelectedGroupRequireID = this.state.selectedGroup
             .group_manager.require_id !== null;
 
@@ -71,7 +66,6 @@ class InstitutionSelector extends Component {
         }
 
         let isIdRightLength = true
-        /*
         if (doesTheSelectedGroupRequireID && isIdPresentIfNeeded) {
             isIdRightLength =
                 this.state.userIdCode.length ===
@@ -85,10 +79,8 @@ class InstitutionSelector extends Component {
                 })
             }
         }
-        */
 
         let codeIsNumber = true
-        /*
         if (
             doesTheSelectedGroupRequireID &&
             isIdPresentIfNeeded &&
@@ -101,10 +93,8 @@ class InstitutionSelector extends Component {
                 })
             }
         }
-        */
 
         if (
-            isThereSelectedGroup &&
             isIdPresentIfNeeded &&
             isIdRightLength &&
             codeIsNumber
@@ -113,7 +103,6 @@ class InstitutionSelector extends Component {
         }
 
         return (
-            isThereSelectedGroup &&
             isIdPresentIfNeeded &&
             isIdRightLength &&
             codeIsNumber
@@ -339,7 +328,6 @@ class InstitutionSelector extends Component {
         if (elements.length === 0) {
             return null
         }
-
         let pair = null
         const rowedElements = []
 

--- a/src/components/Groups/InstitutionSelector.js
+++ b/src/components/Groups/InstitutionSelector.js
@@ -142,6 +142,24 @@ class InstitutionSelector extends Component {
             })
     }
 
+	insertSortToGroupList(data){
+		let groupList = this.state.groupList.slice()
+
+		groupList.push(data)
+		for (let i=parseInt(groupList.length)-1; i>0; i-=1){
+			if (groupList[i]['id'] < groupList[i-1]['id']){
+				let tmp = groupList[i]
+				groupList[i] = groupList[i-1]
+				groupList[i-1] = tmp
+			}
+			else {
+				break
+			}
+		}
+
+		this.setState({ groupList })
+	}
+
     async getGroup(id, setAlert = true) {
         if (setAlert) this.props.setAlert(true)
         this.setState({ idCodeInputShow: false })
@@ -183,11 +201,8 @@ class InstitutionSelector extends Component {
                         key: -1,
                     })
 
-                    const groupList = this.state.groupList.slice()
-                    groupList.push(response.body)
-
+                    this.insertSortToGroupList({...response.body, id: parseInt(id)})
                     this.setState({ selectionIndexes })
-                    this.setState({ groupList })
                 }
             })
             .then(() => {
@@ -208,7 +223,7 @@ class InstitutionSelector extends Component {
                     const { groups } = response.body
                     const selectionIndexes = []
 
-                    groups.map(async (group) => {
+                    groups.forEach(async (group) => {
                         await this.getChildren(group.id, false)
 
                         selectionIndexes.push({

--- a/src/components/Groups/InstitutionSelector.js
+++ b/src/components/Groups/InstitutionSelector.js
@@ -43,11 +43,6 @@ class InstitutionSelector extends Component {
         }
     }
 
-    componentWillUnmount(){
-        delete this.state
-        console.warn(this.state)
-    }
-
     // eslint-disable-next-line react/sort-comp
     isInputValid() {
         if (this.state.groupCheckbox === false) {
@@ -72,6 +67,7 @@ class InstitutionSelector extends Component {
         }
 
         let isIdRightLength = true
+        /*
         if (doesTheSelectedGroupRequireID && isIdPresentIfNeeded) {
             isIdRightLength =
                 this.state.userIdCode.length ===
@@ -85,8 +81,10 @@ class InstitutionSelector extends Component {
                 })
             }
         }
+        */
 
         let codeIsNumber = true
+        /*
         if (
             doesTheSelectedGroupRequireID &&
             isIdPresentIfNeeded &&
@@ -99,6 +97,7 @@ class InstitutionSelector extends Component {
                 })
             }
         }
+        */
 
         if (
             isIdPresentIfNeeded &&


### PR DESCRIPTION
**Descrição**<br>
O bug foi reproduzido quando uma pessoa já é cadastrada ai ela muda dois campos: o primeiro e o filho desse primeiro, e sai da página de editar perfil sem salvar. Para corrigir isso foi apagado todo o estado armazenado assim que o usuário sai da página. 

Testei outros tipos de uso e não achei nenhum bug.

Além disso, o valor do seletor seguinte ao seletor alterado foi apagado para seguir a lógica. Por exemplo: quando o cadastro estava completo e mudava o estado de DF para BA, aparecia a cidade Gama no campo de cidade. Então a partir dessa alteração aparecerar "Select". 

**Checklist**
- [x] Código compila corretamente (Se aplicável);
- [ ] Mudanças realizadas foram testadas e passaram no testes (Se aplicável);
- [ ] Documentos gerados/atualizados (Se aplicável);
- [x] Feito por conta própria (Se aplicável).
