### PR TITLE
Remove institution from Register

### DIFF
--- a/src/screens/inicio/Register/index.js
+++ b/src/screens/inicio/Register/index.js
@@ -32,7 +32,6 @@ import {
 } from '../../../components/NormalForms'
 import { PageTitle, FormLabel, FormTip } from './styles'
 
-import InstitutionSelector from '../../../components/Groups/InstitutionSelector'
 import LoadingModal from '../../../components/Groups/LoadingModal'
 import translate from '../../../../locales/i18n'
 import { scale } from '../../../utils/scalling'
@@ -60,14 +59,11 @@ const Register = ({ navigation }) => {
     const [city, setCity] = useState('')
     const [race, setRace] = useState('')
     const [birth, setBirth] = useState('')
-    const [groupId, setGroupId] = useState(null)
-    const [idCode, setIdCode] = useState(null)
     const [riskGroup, setRiskGroup] = useState(false)
     const [isProfessional, setIsProfessional] = useState(false)
 
     const [countryCheckbox, setCountryCheckbox] = useState(true)
     const [modalRiskGroup, setModalRiskGroup] = useState(false)
-    const [institutionError, setInstituitionError] = useState(null)
     const [loadingAlert, setLoadingAlert] = useState(false)
 
     const passwordInput = useRef()
@@ -110,14 +106,12 @@ const Register = ({ navigation }) => {
             residence,
             state,
             city,
-            group_id: groupId,
-            identification_code: idCode,
             is_professional: isProfessional,
             risk_group: riskGroup,
             policy_version: terms.version,
         }
 
-        if (!validPerson(user, institutionError)) return
+        if (!validPerson(user, null)) return
         setLoadingAlert(true)
 
         const response = await createUser(user)
@@ -128,15 +122,6 @@ const Register = ({ navigation }) => {
             setLoadingAlert(false)
             Alert.alert(`O email ${response.body.errors[0].detail.email}`)
         }
-    }
-
-    const setUserInstitutionCallback = (idCode, groupId) => {
-        setIdCode(idCode)
-        setGroupId(groupId)
-    }
-
-    const setInstituitionComponentError = (error) => {
-        setInstituitionError(error)
     }
 
     return (
@@ -314,7 +299,7 @@ const Register = ({ navigation }) => {
                         />
                     </FormInlineCheck>
 
-                    <FormInlineCheck>
+                    <FormInlineCheck space>
                         <CheckBoxStyled
                             title={translate('register.riskGroupLabel')}
                             checked={riskGroup}
@@ -328,13 +313,6 @@ const Register = ({ navigation }) => {
                             />
                         </CheckLabel>
                     </FormInlineCheck>
-
-                    <InstitutionSelector
-                        setUserInstitutionCallback={setUserInstitutionCallback}
-                        setAlert={setLoadingAlert}
-                        setErrorCallback={setInstituitionComponentError}
-                        lightTheme
-                    />
 
                     <FormInline>
                         <FormLabel>{translate('register.email')}</FormLabel>


### PR DESCRIPTION
**Descrição**<br>
Remove o seletor de Instituições da página de Registrar para facilitar o cadastro dos usuários, principalmente quando a Instituição deles não existe no app, diminuindo confusões no cadastro. Essa era uma demanda antiga. <br>


**Checklist**
- [x] Código compila corretamente (Se aplicável);
- [ ] Mudanças realizadas foram testadas e passaram no testes (Se aplicável);
- [ ] Documentos gerados/atualizados (Se aplicável);
- [ ] Feito por conta própria (Se aplicável).
